### PR TITLE
Move from dependencies to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "0.0.9",
   "description": "Detect when element scrolled to view ",
   "main": "inview.js",
-  "dependencies": {
-  },
   "devDependencies": {
     "grunt-execute": "^0.2.2",
     "grunt-jsdoc": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Detect when element scrolled to view ",
   "main": "inview.js",
   "dependencies": {
-    "jsdoc": "^3.3.0-alpha9",
-    "grunt": "^0.4.5",
-    "jsdoc-oblivion": "^0.0.3",
-    "grunt-jsdoc": "^0.5.7"
   },
   "devDependencies": {
-    "grunt-execute": "^0.2.2"
+    "grunt-execute": "^0.2.2",
+    "grunt-jsdoc": "^0.5.7",
+    "grunt": "^0.4.5",
+    "jsdoc-oblivion": "^0.0.3",
+    "jsdoc": "^3.3.0-alpha9"
   },
   "scripts": {
     "test": "npm test"


### PR DESCRIPTION
Having all these dependencies in dependencies rather than devDependencies increases our `npm install` size by ~70 megs. I don't think there are any explicit dependencies in there, so I moved them all to devDependencies.

LMK what you think, or if there's some reason they're there.

Will squash these soon.