### PR TITLE
window.scrollY is not supported in IE

### DIFF
--- a/inview.js
+++ b/inview.js
@@ -77,7 +77,7 @@
 
     var winBottom = winTop + window.innerHeight
 
-    var objTop = obj.getBoundingClientRect().top + window.scrollY
+    var objTop = obj.getBoundingClientRect().top + document.documentElement.scrollTop
 
     var objBottom = objTop + obj.offsetHeight
 


### PR DESCRIPTION
Currently, window.scrollY is not supported in IE. Instead, document.documentElement.scrollTop is a fully compatible solution. See:

"For cross-browser compatibility, use window.pageYOffset instead of window.scrollY. Additionally, older versions of Internet Explorer (< 9) do not support either property and must be worked around by checking other non-standard properties. A fully compatible example:"
https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY?redirectlocale=en-US&redirectslug=DOM%2Fwindow.scrollY#Notes